### PR TITLE
Fix LspDiagnosticsChanged not firing

### DIFF
--- a/lua/diagnostic.lua
+++ b/lua/diagnostic.lua
@@ -87,11 +87,12 @@ function M.publish_diagnostics(bufnr)
     util.buf_diagnostics_virtual_text(bufnr, result.diagnostics)
   end
   M.diagnostics_loclist(result)
-
-  vim.schedule_wrap(function()
-    vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
-  end)()
+  M.trigger_diagnostics_changed()
 end
+
+M.trigger_diagnostics_changed = vim.schedule_wrap(function()
+    vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
+end)
 
 function M.refresh_diagnostics()
   local bufnr = vim.api.nvim_win_get_buf(0)

--- a/lua/diagnostic.lua
+++ b/lua/diagnostic.lua
@@ -90,7 +90,7 @@ function M.publish_diagnostics(bufnr)
 
   vim.schedule_wrap(function()
     vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
-  end)
+  end)()
 end
 
 function M.refresh_diagnostics()


### PR DESCRIPTION
I had a problem with `LspDiagnosticsChanged` not firing, and traced it to the change in #21, and I dug a bit more and found the following: `vim.schedule_wrap()` returns a function that needs to be executed in order to schedule the actual execution of the function taken by `schedule_wrap()`