### PR TITLE
Ensure that diagnostic character-positions are > 0 (index-out-of-bounds error)

### DIFF
--- a/lua/diagnostic.lua
+++ b/lua/diagnostic.lua
@@ -74,6 +74,7 @@ function M.publish_diagnostics(bufnr)
   if #vim.lsp.buf_get_clients() == 0 then return end
   local diagnostics = vim.lsp.util.diagnostics_by_buf[bufnr]
   if diagnostics == nil then return end
+  util.align_diagnostic_indices(diagnostics)
   vim.fn.setloclist(0, {}, 'r')
   if vim.api.nvim_get_var('diagnostic_enable_underline') == 1 then
     vim.lsp.util.buf_diagnostics_underline(bufnr, diagnostics)

--- a/lua/diagnostic/util.lua
+++ b/lua/diagnostic/util.lua
@@ -179,4 +179,11 @@ function M.buf_diagnostics_signs(bufnr, diagnostics)
   end
 end
 
+function M.align_diagnostic_indices(diagnostics)
+  for idx, diagnostic in ipairs(diagnostics) do
+    if diagnostic.range.start.character < 0 then diagnostic.range.start.character = 0 end
+    if diagnostic.range['end'].character < 0 then diagnostic.range['end'].character = 0 end
+  end
+end
+
 return M


### PR DESCRIPTION
Some language clients will set the diagnostic.range.start.character = -1
for particular sorts of issues, which causes an "index-out-of-bounds"
error when setting virtual text. This fix makes sure all characters
start / end positions are are (at least) 0.