### PR TITLE
Change call to refresh_diagnostics() to be delayed

### DIFF
--- a/lua/diagnostic.lua
+++ b/lua/diagnostic.lua
@@ -98,6 +98,12 @@ function M.refresh_diagnostics()
   M.publish_diagnostics(bufnr)
 end
 
+function M.on_BufEnter()
+  vim.schedule(function()
+    M.refresh_diagnostics()
+  end)
+end
+
 function M.on_InsertLeave()
   M.refresh_diagnostics()
 end
@@ -115,7 +121,7 @@ M.on_attach = function(_, _)
   M.modifyCallback()
   vim.api.nvim_command [[augroup DiagnosticRefresh]]
     vim.api.nvim_command("autocmd! * <buffer>")
-    vim.api.nvim_command [[autocmd BufEnter,BufWinEnter,TabEnter <buffer> lua require'diagnostic'.refresh_diagnostics()]]
+    vim.api.nvim_command [[autocmd BufEnter,BufWinEnter,TabEnter <buffer> lua require'diagnostic'.on_BufEnter()]]
   vim.api.nvim_command [[augroup end]]
 
   if vim.api.nvim_get_var('diagnostic_insert_delay') == 1 then


### PR DESCRIPTION
Changing the location list from `autocmd` can cause problems. As a workaround, delay the call to `refresh_diagnostics()`.

The solution to this problem in vim/vim@b6f1480 was to raise an error if the location list or quickfix was changed from `autocmd`. vim/vim@4d170af also followed this. Therefore, in the current implementation of diagnostic-nvim, all jumps from the location list will result in an error. This PR delays the call to `refresh_diagnostics()` as a workaround.

Maybe in the future someone will find a better way to fix `qf_jump` of vim.

Ref neovim/neovim#12890.