### PR TITLE
Support buffer-local show_sign and enable_virtual_text options

### DIFF
--- a/lua/diagnostic.lua
+++ b/lua/diagnostic.lua
@@ -79,18 +79,37 @@ function M.publish_diagnostics(bufnr)
   if vim.api.nvim_get_var('diagnostic_enable_underline') == 1 then
     vim.lsp.util.buf_diagnostics_underline(bufnr, diagnostics)
   end
-  if vim.api.nvim_get_var('diagnostic_show_sign') == 1 then
+
+  local show_sign
+
+  if vim.b.diagnostic_show_sign ~= nil then
+    show_sign = vim.b.diagnostic_show_sign
+  else
+    show_sign = vim.api.nvim_get_var('diagnostic_show_sign')
+  end
+
+  if show_sign == 1 then
     util.buf_diagnostics_signs(bufnr, diagnostics)
   end
-  if vim.api.nvim_get_var('diagnostic_enable_virtual_text') == 1 then
+
+  local virtual_text
+
+  if vim.b.diagnostic_enable_virtual_text ~= nil then
+    virtual_text = vim.b.diagnostic_enable_virtual_text
+  else
+    virtual_text = vim.api.nvim_get_var('diagnostic_enable_virtual_text')
+  end
+
+  if virtual_text == 1 then
     util.buf_diagnostics_virtual_text(bufnr, diagnostics)
   end
+
   M.diagnostics_loclist(diagnostics)
   M.trigger_diagnostics_changed()
 end
 
 M.trigger_diagnostics_changed = vim.schedule_wrap(function()
-    vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
+  vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
 end)
 
 function M.refresh_diagnostics()
@@ -114,14 +133,14 @@ M.on_attach = function(_, _)
   -- Setup autocmd
   M.modifyCallback()
   vim.api.nvim_command [[augroup DiagnosticRefresh]]
-    vim.api.nvim_command("autocmd! * <buffer>")
-    vim.api.nvim_command [[autocmd BufEnter,BufWinEnter,TabEnter <buffer> lua require'diagnostic'.refresh_diagnostics()]]
+  vim.api.nvim_command("autocmd! * <buffer>")
+  vim.api.nvim_command [[autocmd BufEnter,BufWinEnter,TabEnter <buffer> lua require'diagnostic'.refresh_diagnostics()]]
   vim.api.nvim_command [[augroup end]]
 
   if vim.api.nvim_get_var('diagnostic_insert_delay') == 1 then
     vim.api.nvim_command [[augroup DiagnosticInsertDelay]]
-      vim.api.nvim_command("autocmd! * <buffer>")
-      vim.api.nvim_command [[autocmd InsertLeave <buffer> lua require'diagnostic'.on_InsertLeave()]]
+    vim.api.nvim_command("autocmd! * <buffer>")
+    vim.api.nvim_command [[autocmd InsertLeave <buffer> lua require'diagnostic'.on_InsertLeave()]]
     vim.api.nvim_command [[augroup end]]
   end
 end


### PR DESCRIPTION
This pull request may not be merged exactly as-is. But I'm including it here to show a principle and hopefully start a debate.

One of the things I like to/want to do is enable and disable the LSP support on a per-buffer basis ("this virtual text is annoying, hide it!"). Currently that's not really practical. What this pull request does is introduce two-buffer local variables, `vim.b.diagnostic_enable_virtual_text` and `vim.b.diagnostic_show_sign`, which can be turned on or off per-buffer. This enables me to create a toggle function (not included in this pull request, as it sits outside the plugin) which turns them on or off.

Is this the kind of thing which you'd be open to see being included in `diagnostic-nvim`? Currently one big limitation I see with LSP support in Nvim is it's kinda 'all or nothing' on a per-filetype basis - you can't temporarily disable it for one buffer. This would allow for that (and other patterns).